### PR TITLE
Typo: Lusture to Lustre

### DIFF
--- a/packages/gleamtours/src/gleamtours/dev.gleam
+++ b/packages/gleamtours/src/gleamtours/dev.gleam
@@ -207,7 +207,7 @@ fn build() {
       "/gleamtours/tours/01_lustre_tutorial",
       "Lustre tutorial",
       "lustre-tutorial",
-      "Get started building your first web app with the Lusture tutorial.",
+      "Get started building your first web app with the Lustre tutorial.",
     ),
   ]
   use lessons <- t.do(
@@ -300,7 +300,7 @@ fn build() {
   // let tours = [
   //   #(
   //     "Lustre tutorial",
-  //     "Get started building your first web app with the Lusture tutorial.",
+  //     "Get started building your first web app with the Lustre tutorial.",
   //     "/lustre-tutorial/introduction/welcome-to-lustre",
   //   ),
   // #(


### PR DESCRIPTION
Sorry, I came, was amazed, went back to the home page, saw, and broke my brain.

This just replaces the word "Lusture" with "Lustre" in dev.gleam, as far as I saw the only occurence.